### PR TITLE
Noise generator ported from Python. Tests included

### DIFF
--- a/Evo_Roguelike/Assets/Scenes/PCGTestScene.unity
+++ b/Evo_Roguelike/Assets/Scenes/PCGTestScene.unity
@@ -1,0 +1,345 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 3
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 0
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &1338304545
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1338304550}
+  - component: {fileID: 1338304549}
+  - component: {fileID: 1338304548}
+  - component: {fileID: 1338304547}
+  - component: {fileID: 1338304546}
+  m_Layer: 0
+  m_Name: Quad
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1338304546
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1338304545}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e27fb8272410ba94a81463b837d9814d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  noiseType: 1
+  maskType: 0
+  faderType: 0
+--- !u!64 &1338304547
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1338304545}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 5
+  m_Convex: 0
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &1338304548
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1338304545}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1338304549
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1338304545}
+  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1338304550
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1338304545}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.8486, y: -0.4159, z: 0}
+  m_LocalScale: {x: 9.2196, y: 8.221073, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1921411471
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1921411474}
+  - component: {fileID: 1921411473}
+  - component: {fileID: 1921411472}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &1921411472
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1921411471}
+  m_Enabled: 1
+--- !u!20 &1921411473
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1921411471}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 1
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &1921411474
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1921411471}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 1921411474}
+  - {fileID: 1338304550}

--- a/Evo_Roguelike/Assets/Scenes/PCGTestScene.unity.meta
+++ b/Evo_Roguelike/Assets/Scenes/PCGTestScene.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: fc0d6e564b9bfe24fb4e903fa0199441
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Evo_Roguelike/Assets/Scripts/PCG.meta
+++ b/Evo_Roguelike/Assets/Scripts/PCG.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3475cb50992fb164dbc0ae0898dbd658
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Evo_Roguelike/Assets/Scripts/PCG/Generators.cs
+++ b/Evo_Roguelike/Assets/Scripts/PCG/Generators.cs
@@ -1,0 +1,399 @@
+// Support Classes and Data Types
+using System;
+using UnityEngine;
+
+public struct NormalizingValues
+{
+    // Simple struct to return the values needed to normalize
+    // the output of a Generator
+    public float min;
+    public float max;
+
+    public NormalizingValues(float min, float max)
+    {
+        this.min = min;
+        this.max = max;
+    }
+}
+
+// Enums for the factories
+public enum NoiseGeneratorType
+{
+    Default,
+    Perlin
+}
+
+public enum MaskGeneratorType
+{
+    Default,
+    Radial,
+    Elliptical, // To do
+    Rectangular // To do
+}
+
+public enum FaderType
+{
+    Default,
+    Linear,
+    Hyperbolic
+}
+
+// High level classes
+public interface IGeneratorStrategy
+{
+    // A Generator Strategy the mechanism the Generator
+    // class uses to create the value for a "pixel" in the map
+
+    // This function takes location coordinates and outputs the "height" value
+    // at that coordinate.
+    public float GeneratePixelValue(int x, int y);
+
+    // Some generators can produce values outside of the range 0-1
+    // To ensure output remains within the desired 0-1 range, the Generator
+    // can use these normalizing to remap output data.
+    public NormalizingValues GetNormalizingValues();
+
+}
+
+public interface IFaderStrategy
+{
+    // Faders fade out a mask in proportion to some distance
+    // to its bounds.
+    public float Fade(float distance);
+}
+
+public static class GeneratorFactory
+{
+    // The generator factory is the class through which GeneratorStrategies
+    // are produced.
+    public static IGeneratorStrategy MakeNoiseGenerator(NoiseGeneratorType type)
+    {
+        // Noise generators can be extended if we find that perlin is not good enough
+        switch (type)
+        {
+            case NoiseGeneratorType.Perlin:
+                return new PerlinNoiseGenerator();
+            default:
+                return new RandomNoiseGenerator();
+        }
+    }
+
+    public static IGeneratorStrategy MakeMaskGenerator(MaskGeneratorType type, IFaderStrategy fader)
+    {
+        // Masks act in combination with the noise generators to give shape to the terrain.
+        switch (type)
+        {
+            case MaskGeneratorType.Radial:
+                return new RadialMask(fader);
+            default:
+                return new NoMask(fader);
+        }
+    }
+}
+
+public static class FaderFactory
+{
+    public static IFaderStrategy MakeFader(FaderType type)
+    {
+        switch (type)
+        {
+            case FaderType.Hyperbolic:
+                return new HyperbolicFader();
+            case FaderType.Linear:
+                return new LinearFader();
+            default:
+                return new NoFade();
+        }
+    }
+}
+
+// Faders
+public class NoFade : IFaderStrategy
+{
+    // Does nothing. Yay!
+    public float Fade(float distance)
+    {
+        if (distance <= 0)
+        {
+            return 1.0f;
+        }
+        return 0.0f;
+    }
+}
+
+public class LinearFader : IFaderStrategy
+{
+    // Linearly fade away from 1
+    private float _gradient;
+    public LinearFader()
+    {
+        _gradient = PCGConfig.fadeGradient;
+    }
+    public float Fade(float distance)
+    {
+        return Mathf.Clamp(1.0f - (distance * _gradient), 0.0f, 1.0f);
+    }
+}
+
+public class HyperbolicFader : IFaderStrategy
+{
+    // Ease out of 1 and ease into 0, but steep gradient through the middle
+    public float Fade(float distance)
+    {
+        if (distance <= 0)
+        {
+            return 1.0f;
+        } else if (distance >= 1)
+        {
+            return 0.0f;
+        }
+
+        float inverted_distance = 1 - distance;
+        // The output function of this fader can be seen here https://www.desmos.com/calculator/hi3mksaava
+        // and is constrained to the domain of [0,1]
+        return 0.5f * MathF.Tanh(4 * inverted_distance - 2) + 0.5f; 
+    }
+}
+
+// Noise Generators
+public class RandomNoiseGenerator : IGeneratorStrategy
+{
+    // Pure random noise generator. Will rarely be used but is a useful default scenario.
+    public float GeneratePixelValue(int x, int y)
+    {
+        return UnityEngine.Random.Range(0.0f, 1.0f);
+    }
+
+    public NormalizingValues GetNormalizingValues()
+    {
+        return new NormalizingValues(0.0f, 1.0f);
+    }
+}
+
+public class PerlinNoiseGenerator : IGeneratorStrategy
+{
+    // Extension wrapping for the Unity Perlin noise generator
+    // Adds FBM to the output.
+    // Mind you, Unity PerlinNoise is not random.
+    // Textually "The same coordinates will always return the same sample value" (https://docs.unity3d.com/ScriptReference/Mathf.PerlinNoise.html)
+    // So we create offsets using a random seed determined at construction
+
+    private Vector2 _seed;
+    private float _minValue = 10;
+    private float _maxValue = -10;
+    public PerlinNoiseGenerator()
+    {
+        _seed = new Vector2(UnityEngine.Random.Range(0, 9999f), UnityEngine.Random.Range(0, 9999f));
+    }
+
+    // Debugging method to ensure consistent output
+    public void SetSeed(Vector2 value)
+    {
+        _seed = value;
+    }
+
+    public float GeneratePixelValue(int x, int y)
+    {
+        //float noise = FractalBrownianMotion(x, y);
+        float noise = FractalBrownianMotion(x, y);
+        UpdateNormalizingValues(noise);
+        return noise;
+    }
+
+    public NormalizingValues GetNormalizingValues()
+    {
+        return new NormalizingValues(_minValue, _maxValue);
+    }
+
+    private float FractalBrownianMotion(float x, float y)
+    {
+        float result = 0.0f;
+        float frequency = PCGConfig.starting_frequency;
+        float newX;
+        float newY;
+        float amplitude = PCGConfig.amplitude_factor;
+
+        for (int i = 0; i < PCGConfig.octaves; i++)
+        {
+            newX = _seed.x + x / PCGConfig.scale * frequency;
+            newY = _seed.y + y / PCGConfig.scale * frequency;
+            result += amplitude * NoiseAtCoordinate(newX, newY);
+            frequency *= PCGConfig.lacunarity;
+            amplitude *= PCGConfig.amplitude_factor;
+        }
+        return result;
+        
+    }
+
+    private float NoiseAtCoordinate(float x, float y)
+    {
+
+        
+        float sample = Mathf.PerlinNoise(_seed.x + x, _seed.y + y) * 2 - 1;
+        return sample;
+    }
+
+    private void UpdateNormalizingValues(float noise)
+    {
+        if (noise < _minValue)
+        {
+            _minValue = noise;
+        } else if (noise > _maxValue)
+        {
+            _maxValue = noise;
+        }
+    }
+}
+
+// Masks
+public abstract class Mask : IGeneratorStrategy
+{
+    // A mask creates an area that allows noise values to pass through.
+    // Values that lie outside its region fade out according to the fade strategy of the mask
+    protected IFaderStrategy _fader;
+    public Mask(IFaderStrategy fader)
+    {
+        _fader = fader;
+    }
+
+    public NormalizingValues GetNormalizingValues()
+    {
+        return new NormalizingValues(0.0f, 1.0f);
+    }
+
+    public abstract float GeneratePixelValue(int x, int y);
+}
+
+public class NoMask : Mask
+{
+    // Does nothing. Yay!
+    // That is, this mask does not affect the output - it returns the input as is.
+    public NoMask(IFaderStrategy fader) : base(fader){}
+    public override float GeneratePixelValue(int x, int y)
+    {
+        return 1.0f;
+    }
+}
+
+public class RadialMask : Mask
+{
+    // A circular mask
+    public RadialMask(IFaderStrategy fader) : base(fader){}
+
+    public override float GeneratePixelValue(int x, int y)
+    {
+        float _radius = PCGConfig.radialMaskRadius;
+        Vector2 _center = PCGConfig.radialMaskCenter;
+        // Distance is calculated as a factor of the radius
+        Vector2 coordinates = new Vector2(x, y);
+        float distance = Vector2.Distance(coordinates, _center);
+        float radius_proportional_distance = (distance / _radius) - 1.0f;
+        return _fader.Fade(radius_proportional_distance);
+    }
+}
+
+public class Generator
+{
+    public IGeneratorStrategy noiseGenerationStrategy;
+    IGeneratorStrategy mask;
+    public float[,] noiseMap = new float[0,0];
+
+
+    
+    
+    public Generator( NoiseGeneratorType noiseType, MaskGeneratorType maskType, FaderType faderType)
+    {
+        noiseGenerationStrategy = GeneratorFactory.MakeNoiseGenerator(noiseType);
+        IFaderStrategy fader = FaderFactory.MakeFader(faderType);
+        mask = GeneratorFactory.MakeMaskGenerator(maskType, fader);
+    }
+
+    // Additional constructor using all default types. Likely won't be used in production but useful for testing
+    public Generator()
+    {
+        noiseGenerationStrategy = GeneratorFactory.MakeNoiseGenerator(NoiseGeneratorType.Default);
+        IFaderStrategy fader = FaderFactory.MakeFader(FaderType.Default);
+        mask = GeneratorFactory.MakeMaskGenerator(MaskGeneratorType.Default, fader);
+    }
+
+    // Additional constructor to allow for custom setting of noise generators (mostly for debugging purposes)
+    public Generator(MaskGeneratorType maskType, FaderType faderType)
+    {
+        IFaderStrategy fader = FaderFactory.MakeFader(faderType);
+        mask = GeneratorFactory.MakeMaskGenerator(maskType, fader);
+    }
+
+    public void SetNoiseGenerator(IGeneratorStrategy gs)
+    {
+        noiseGenerationStrategy = gs;
+    }
+
+    public void VoidCache()
+    {
+        noiseMap = new float[0, 0];
+    }
+
+    public float[,] GenerateNoiseArray(Vector2 size)
+    {
+        // This function and the following create the noise array
+        // This version takes a Vector2 to describe the canvas size
+
+        // Use a cache first if one exists
+        if (noiseMap.Length > 0)
+        {
+            return noiseMap;
+        }
+        
+        int width = (int)size.x;
+        int height = (int)size.y;
+        float[,] noiseOutput = new float[width,height];
+        PopulateNoiseValues(width, height, noiseOutput);
+        return noiseOutput;
+    }
+
+    public float[,] GenerateNoiseArray(int width, int height)
+    {
+        // This version takes an int for width and an int for height.
+        // Both versions essentially just call the underlying PopulateNoiseValues function
+
+        // Use a cache first if one exists
+        if (noiseMap.Length > 0)
+        {
+            return noiseMap;
+        }
+
+        float[,] noiseOutput = new float[width, height];
+        PopulateNoiseValues(width, height, noiseOutput);
+        return noiseOutput;
+    }
+
+    private void PopulateNoiseValues(int width, int height, float[,] container)
+    {
+        // This function populates a grid of noise values
+        // It takes as inputs the dimensions of the grid and the array that represents it
+        // It outputs nothing but modifies the input array directly
+
+        // Generate the noise values
+        for (int i = 0; i < height; i++)
+        {
+            for (int j = 0; j < width; j++)
+            {
+                container[j, i] = noiseGenerationStrategy.GeneratePixelValue(j, i);
+            }
+        }
+
+        //Normalize and mask them
+        NormalizingValues norm = noiseGenerationStrategy.GetNormalizingValues();
+        for (int i = 0; i < height; i++)
+        {
+            for (int j = 0; j < width; j++)
+            {
+                container[j, i] = Mathf.InverseLerp(norm.min, norm.max, container[j, i]);
+                container[j, i] *= mask.GeneratePixelValue(j, i);
+            }
+        }
+
+        //Cache the created noiseMap
+        noiseMap = container;
+    }
+}

--- a/Evo_Roguelike/Assets/Scripts/PCG/Generators.cs.meta
+++ b/Evo_Roguelike/Assets/Scripts/PCG/Generators.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: de6d6637acc3bf545ab1eeebed7382b5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Evo_Roguelike/Assets/Scripts/PCG/PCGConfig.cs
+++ b/Evo_Roguelike/Assets/Scripts/PCG/PCGConfig.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+public static class PCGConfig
+{
+    public static Vector2 radialMaskCenter = new Vector2(360, 360);
+    public static float radialMaskRadius = 200.0f;
+
+    public static int octaves = 4;
+    public static float amplitude_factor = 0.5f;
+    public static float starting_frequency = 1.0f;
+    public static float lacunarity = 2.0f;
+    public static float scale = 50.0f;
+
+    public static float fadeGradient = 1;
+}

--- a/Evo_Roguelike/Assets/Scripts/PCG/PCGConfig.cs.meta
+++ b/Evo_Roguelike/Assets/Scripts/PCG/PCGConfig.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1249d0de82cfa8b49ad3c54bdb9866ba
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Evo_Roguelike/Assets/Scripts/PCG/TerrainGenerationManager.cs
+++ b/Evo_Roguelike/Assets/Scripts/PCG/TerrainGenerationManager.cs
@@ -1,0 +1,42 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class TerrainGenerationManager : MonoBehaviour
+{ 
+    // This class exists for testing purposes of the PCG Test Scene.
+    // It is _not_ intended to be used in production. It is used for visualization testing of the noise generators
+
+    public NoiseGeneratorType noiseType;
+    public MaskGeneratorType maskType;
+    public FaderType faderType;
+
+    public Generator noiseGenerator;
+
+    private Texture2D noiseTex;
+    private Renderer rend;
+    // Start is called before the first frame update
+    void Start()
+    {
+        int height = 720;
+        int width = 720;
+        noiseTex = new Texture2D(width, height);
+        rend = GetComponent<Renderer>();
+        rend.material.mainTexture = noiseTex;
+
+        noiseGenerator = new Generator(noiseType, maskType, faderType);
+        float[,] noiseValues = noiseGenerator.GenerateNoiseArray(width, height);
+
+        for (int i = 0; i < height; i++)
+        {
+            for (int j = 0; j < width; j++)
+            {
+                noiseTex.SetPixel(j, i, new Color(noiseValues[j, i], noiseValues[j, i], noiseValues[j, i]));
+            }
+        }
+
+        noiseTex.Apply();
+    }
+
+    
+}

--- a/Evo_Roguelike/Assets/Scripts/PCG/TerrainGenerationManager.cs.meta
+++ b/Evo_Roguelike/Assets/Scripts/PCG/TerrainGenerationManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e27fb8272410ba94a81463b837d9814d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Evo_Roguelike/Assets/Tests/EditTests/GeneratorTests.cs
+++ b/Evo_Roguelike/Assets/Tests/EditTests/GeneratorTests.cs
@@ -1,0 +1,362 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+public class ProceduralGenerationTests
+{
+    #region Fader Tests
+    [Test]
+    public void TestFadeFactory()
+    {
+        // All factory methods execute without throwing an error
+        Assert.DoesNotThrow(() => FaderFactory.MakeFader(FaderType.Linear));
+        Assert.DoesNotThrow(() => FaderFactory.MakeFader(FaderType.Hyperbolic));
+        Assert.DoesNotThrow(() => FaderFactory.MakeFader(FaderType.Default));
+    }
+
+    [Test]
+    public void TestNoFade()
+    {
+        IFaderStrategy fader = FaderFactory.MakeFader(FaderType.Default);
+        float expectedHigh = 1.0f;
+        float expectedLow = 0.0f;
+        
+        float negativeTestValue = -1.0f;
+        float zeroTestValue = 0.0f;
+        float positiveTestValue = 0.5f;
+        float largePositiveTestvalue = 5.5f;
+
+        //Negative values means that the test point is within the mask.
+        //No diminishing of the signal should happen
+        Assert.AreEqual(expectedHigh, fader.Fade(negativeTestValue));
+        Assert.AreEqual(expectedHigh, fader.Fade(zeroTestValue));
+
+        //Positive values means that the test point is outside the mask
+        //NoFade sets values outside the mask to 0
+        Assert.AreEqual(expectedLow, fader.Fade(positiveTestValue));
+        Assert.AreEqual(expectedLow, fader.Fade(largePositiveTestvalue));
+    }
+
+    [Test]
+    public void TestLinearFade()
+    {
+        IFaderStrategy fader = FaderFactory.MakeFader(FaderType.Linear);
+        float negativeTestValue = -1.0f;
+        float zeroTestValue = 0.0f;
+        float positiveTestValue = 0.5f;
+        float largePositiveTestvalue = 5.5f;
+
+        float expectedHigh = 1.0f;
+        float expectedLow = 0.0f;
+        float expectedMidpoint = positiveTestValue * PCGConfig.fadeGradient;
+        float lowGradient = fader.Fade(0.3f) - fader.Fade(0.2f);
+        float highGradient = fader.Fade(0.8f) - fader.Fade(0.7f);
+
+        //Negative values means that the test point is within the mask.
+        //No diminishing of the signal should happen
+        Assert.AreEqual(expectedHigh, fader.Fade(negativeTestValue));
+        Assert.AreEqual(expectedHigh, fader.Fade(zeroTestValue));
+
+        //Positive values means that the test point is outside the mask
+        //Linear fade attenuates the signal outside the mask linearly
+        Assert.AreEqual(expectedMidpoint, fader.Fade(positiveTestValue));
+        Assert.AreEqual(expectedLow, fader.Fade(largePositiveTestvalue));
+
+        //Test that gradient is the same in all locations of the fader
+        Assert.AreEqual(lowGradient, highGradient);
+    }
+
+    [Test]
+    public void TestHyperbolicFade()
+    {
+        IFaderStrategy fader = FaderFactory.MakeFader(FaderType.Hyperbolic);
+        float negativeTestValue = -1.0f;
+        float zeroTestValue = 0.0f;
+        float lowPositiveTestValue = 0.2f;
+        float positiveTestValue = 0.6f;
+        float largePositiveTestvalue = 5.5f;
+
+        float expectedHigh = 1.0f;
+        float expectedLow = 0.0f;
+        float expectedLowPositive = 0.5f * MathF.Tanh(4 * (1-lowPositiveTestValue) - 2) + 0.5f;
+        float expectedHighPositive = 0.5f * MathF.Tanh(4 * (1-positiveTestValue) - 2) + 0.5f;
+        float lowGradient = fader.Fade(lowPositiveTestValue + 0.1f) - fader.Fade(lowPositiveTestValue - 0.1f);
+        float highGradient = fader.Fade(positiveTestValue + 0.1f) - fader.Fade(positiveTestValue - 0.1f);
+
+        //Negative values means that the test point is within the mask.
+        //No diminishing of the signal should happen
+        Assert.AreEqual(expectedHigh, fader.Fade(negativeTestValue));
+        Assert.AreEqual(expectedHigh, fader.Fade(zeroTestValue));
+
+        //Positive values means that the test point is outside the mask
+        //Hyperbolic fade attenuates in a changing gradient within the range [0,1]
+        Assert.AreEqual(expectedLowPositive, fader.Fade(lowPositiveTestValue));
+        Assert.AreEqual(expectedHighPositive, fader.Fade(positiveTestValue));
+        Assert.AreEqual(expectedLow, fader.Fade(largePositiveTestvalue));
+
+        //Test for the changing gradient
+        Assert.AreNotEqual(lowGradient, highGradient);
+    }
+    #endregion
+    #region Mask Tests
+    [Test]
+    public void TestMaskFactory()
+    {
+        IFaderStrategy noFade = FaderFactory.MakeFader(FaderType.Default);
+        Assert.DoesNotThrow(() => GeneratorFactory
+                .MakeMaskGenerator(MaskGeneratorType.Default, noFade));
+        Assert.DoesNotThrow(() => GeneratorFactory
+                .MakeMaskGenerator(MaskGeneratorType.Elliptical, noFade));
+        Assert.DoesNotThrow(() => GeneratorFactory
+                .MakeMaskGenerator(MaskGeneratorType.Radial, noFade));
+        Assert.DoesNotThrow(() => GeneratorFactory
+                .MakeMaskGenerator(MaskGeneratorType.Rectangular, noFade));
+    }
+
+    [Test]
+    public void TestNoMask()
+    {
+        // Arrange masks
+        IFaderStrategy noFade = FaderFactory.MakeFader(FaderType.Default);
+        IFaderStrategy linearFade = FaderFactory.MakeFader(FaderType.Linear);
+        IFaderStrategy hbFader = FaderFactory.MakeFader(FaderType.Hyperbolic);
+        IGeneratorStrategy pureMask = GeneratorFactory
+            .MakeMaskGenerator(MaskGeneratorType.Default, noFade);
+        IGeneratorStrategy linearMask = GeneratorFactory
+            .MakeMaskGenerator(MaskGeneratorType.Default, linearFade);
+        IGeneratorStrategy hbMask = GeneratorFactory
+            .MakeMaskGenerator(MaskGeneratorType.Default, hbFader);
+
+        //Arrange test cases
+        float expectedValue = 1.0f;
+
+        //Test Locations
+        Vector2 centralPosition = new Vector2(360.0f, 360.0f);
+        Vector2 fringePosition1 = new Vector2(0.0f, 0.0f);
+        Vector2 fringePosition2 = new Vector2(720.0f, 720.0f);
+
+        // Act - Calculate mask outputs
+        float pureCentralOutput = pureMask.GeneratePixelValue(
+            (int) centralPosition.x, (int) centralPosition.y);
+        float pureFringeOutput1 = pureMask.GeneratePixelValue(
+            (int) fringePosition1.x, (int) fringePosition2.y);
+        float pureFringeOutput2 = pureMask.GeneratePixelValue(
+            (int)fringePosition2.x, (int)fringePosition2.y);
+
+        float linearCentralOutput = linearMask.GeneratePixelValue(
+            (int)centralPosition.x, (int)centralPosition.y);
+        float linearFringeOutput1 = linearMask.GeneratePixelValue(
+            (int)fringePosition1.x, (int)fringePosition2.y);
+        float linearFringeOutput2 = linearMask.GeneratePixelValue(
+            (int)fringePosition2.x, (int)fringePosition2.y);
+
+        float hbCentralOutput = hbMask.GeneratePixelValue(
+            (int)centralPosition.x, (int)centralPosition.y);
+        float hbFringeOutput1 = hbMask.GeneratePixelValue(
+            (int)fringePosition1.x, (int)fringePosition2.y);
+        float hbFringeOutput2 = hbMask.GeneratePixelValue(
+            (int)fringePosition2.x, (int)fringePosition2.y);
+
+        // Assert
+        Assert.AreEqual(expectedValue, pureCentralOutput);
+        Assert.AreEqual(expectedValue, pureFringeOutput1);
+        Assert.AreEqual(expectedValue, pureFringeOutput2);
+
+        Assert.AreEqual(expectedValue, linearCentralOutput);
+        Assert.AreEqual(expectedValue, linearFringeOutput1);
+        Assert.AreEqual(expectedValue, linearFringeOutput2);
+
+        Assert.AreEqual(expectedValue, hbCentralOutput);
+        Assert.AreEqual(expectedValue, hbFringeOutput1);
+        Assert.AreEqual(expectedValue, hbFringeOutput2);
+
+    }
+
+    [Test]
+    public void TestRadialMask()
+    {
+        // Arrange masks
+        IFaderStrategy noFade = FaderFactory.MakeFader(FaderType.Default);
+        IFaderStrategy linearFade = FaderFactory.MakeFader(FaderType.Linear);
+        IFaderStrategy hbFader = FaderFactory.MakeFader(FaderType.Hyperbolic);
+        IGeneratorStrategy pureMask = GeneratorFactory
+            .MakeMaskGenerator(MaskGeneratorType.Radial, noFade);
+        IGeneratorStrategy linearMask = GeneratorFactory
+            .MakeMaskGenerator(MaskGeneratorType.Radial, linearFade);
+        IGeneratorStrategy hbMask = GeneratorFactory
+            .MakeMaskGenerator(MaskGeneratorType.Radial, hbFader);
+
+        //Arrange test cases
+
+        //Half a radius away
+        Vector2 withinMaskPosition = new Vector2(
+            PCGConfig.radialMaskCenter.x - PCGConfig.radialMaskRadius * 0.5f,
+            PCGConfig.radialMaskCenter.y);
+
+        //1.3 radii away
+        Vector2 outsideMaskPosition = new Vector2(
+            PCGConfig.radialMaskCenter.x - PCGConfig.radialMaskRadius * 1.3f,
+            PCGConfig.radialMaskCenter.y);
+
+        // Arrange expected values
+        float expectedOutputWithin = 1.0f;
+        float expectedPureMaskOutputOutside = 0.0f;
+        float expectedLinearMaskOutputOutside = 0.7f;
+        float expectedHyperbolicOutputOutside = 0.5f * MathF.Tanh(4 * 0.7f - 2) + 0.5f;
+        float expectedHyperbolicThreshold = 0.8f;
+
+        // Act
+        float pureMaskOutputWithin = pureMask.GeneratePixelValue(
+            (int)withinMaskPosition.x, 
+            (int)withinMaskPosition.y
+        );
+        float linearMaskOutputWithin = linearMask.GeneratePixelValue(
+            (int)withinMaskPosition.x,
+            (int)withinMaskPosition.y
+        );
+        float hbMaskOutputWithin = hbMask.GeneratePixelValue(
+            (int)withinMaskPosition.x,
+            (int)withinMaskPosition.y
+        );
+
+        float pureMaskOutputOutside = pureMask.GeneratePixelValue(
+            (int)outsideMaskPosition.x,
+            (int)outsideMaskPosition.y
+        );
+        float linearMaskOutputOutside = linearMask.GeneratePixelValue(
+            (int)outsideMaskPosition.x,
+            (int)outsideMaskPosition.y
+        );
+        float hbMaskOutputOutside = hbMask.GeneratePixelValue(
+            (int)outsideMaskPosition.x,
+            (int)outsideMaskPosition.y
+        );
+
+        // Assert
+        Assert.AreEqual(expectedOutputWithin, pureMaskOutputWithin);
+        Assert.AreEqual(expectedOutputWithin, linearMaskOutputWithin);
+        Assert.AreEqual(expectedOutputWithin, hbMaskOutputWithin);
+
+        Assert.AreEqual(expectedPureMaskOutputOutside, pureMaskOutputOutside);
+        Assert.AreEqual(expectedLinearMaskOutputOutside, linearMaskOutputOutside);
+        Assert.AreEqual(expectedHyperbolicOutputOutside, hbMaskOutputOutside);
+        Assert.Greater(hbMaskOutputOutside, expectedHyperbolicThreshold);
+
+
+    }
+    #endregion
+    #region Generator Tests
+    [Test]
+    public void TestNoiseGeneratorFactory()
+    {
+        Assert.DoesNotThrow(() => GeneratorFactory
+                .MakeNoiseGenerator(NoiseGeneratorType.Perlin));
+        Assert.DoesNotThrow(() => GeneratorFactory
+                .MakeNoiseGenerator(NoiseGeneratorType.Default));
+    }
+
+    [Test]
+    public void TestPerlinNoiseSmoothness()
+    {
+        Generator generator = new Generator(MaskGeneratorType.Default, FaderType.Default);
+        //We create the perlin generator separately as this is a randomness test and randomness doesn't always behave
+        PerlinNoiseGenerator perlinNoiseGenerator = new PerlinNoiseGenerator();
+        perlinNoiseGenerator.SetSeed(new Vector2(10f, 10f));
+        generator.SetNoiseGenerator(perlinNoiseGenerator);
+
+        // Arrange testing data
+        float deltaToleranceThreshold = 0.5f; // This is a generous upper threshold but it ensures no two data points are too far apart
+        float width = 20f;
+        float height = 20f;
+        float[,] gridOfTestValues = generator.GenerateNoiseArray(new Vector2(width, height));
+        float rightNeighborDelta;
+        float downNeighborDelta;
+
+        //Test every neighbor downwards and rightwards that the difference in noise values doesn't exceed the deltaToleranceThreshold
+        for (int i = 0; i < height - 1; i++)
+        {
+            for (int j = 0; j < width - 1; j++)
+            {
+                rightNeighborDelta = Mathf.Abs(gridOfTestValues[i,j] - gridOfTestValues[i,j+1]);
+                downNeighborDelta = Mathf.Abs(gridOfTestValues[i,j] - gridOfTestValues[i+1,j]);
+                Assert.Less(rightNeighborDelta, deltaToleranceThreshold);
+                Assert.Less(downNeighborDelta, deltaToleranceThreshold);
+            }
+        }
+    }
+
+    [Test]
+    public void TestValueDistribution()
+    {
+        // Fractal noise is not uniformly distributed, it's closer to Gaussian noise.
+        // This test validates that noise is not uniformly random.
+
+        int[] bins = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+
+        //We create the perlin generator separately as this is a randomness test and randomness doesn't always behave
+        PerlinNoiseGenerator perlinNoiseGenerator = new PerlinNoiseGenerator();
+        perlinNoiseGenerator.SetSeed(new Vector2(10f, 10f));
+        Generator generator = new Generator(MaskGeneratorType.Default, FaderType.Default);
+        generator.SetNoiseGenerator(perlinNoiseGenerator);
+
+        // Big old dataset (1600 entries)
+        float width = 40f;
+        float height = 40f;
+
+        float[,] testValues = generator.GenerateNoiseArray(new Vector2(width, height));
+        int binValue;
+
+        //Run a frequency counter
+        for (int i = 0; i < height - 1; i++)
+        {
+            for (int j = 0; j < width - 1; j++)
+            {
+                //Get the first decimal value (i.e. most significant noise value)
+                binValue = (int) (testValues[i,j] * 10);
+                bins[binValue]++;
+            }
+        }
+
+        // These two values should be approximately similar in frequency
+        float percentageValuesUnderThree = (bins[0] + bins[1] + bins[2]) / (width * height);
+        float percentageValuesOverSeven = (bins[8] + bins[9] + bins[10]) / (width * height);
+        float tailDeltaThreshold = 0.3f;
+        float tailDelta = Mathf.Abs(percentageValuesOverSeven - percentageValuesUnderThree);
+
+        // These values should be more frequently represented than the previous ones
+        float percentageCentralValues = (bins[4] + bins[5] + bins[6]) / (width * height);
+
+        // Assert
+        Assert.Greater(percentageCentralValues, percentageValuesUnderThree);
+        Assert.Greater(percentageCentralValues, percentageValuesOverSeven);
+        Assert.Less(tailDelta, tailDeltaThreshold);
+    }
+
+    [Test]
+    public void TestNoiseValueConstraints()
+    {
+        Generator perlinGenerator = new Generator(NoiseGeneratorType.Perlin, MaskGeneratorType.Default, FaderType.Default);
+        Generator randomGenerator = new Generator();
+        Vector2 testDimensions = new Vector2(40, 40);
+
+        float[,] outputPerlin = perlinGenerator.GenerateNoiseArray(testDimensions);
+        float[,] outputRandom = randomGenerator.GenerateNoiseArray(testDimensions);
+
+        for (int i = 0; i < testDimensions.x; i++)
+        {
+            for (int j = 0; j < testDimensions.y; j++)
+            {
+                Assert.LessOrEqual(outputPerlin[i, j], 1.0f);
+                Assert.GreaterOrEqual(outputPerlin[i, j], 0.0f);
+
+                Assert.LessOrEqual(outputRandom[i, j], 1.0f);
+                Assert.GreaterOrEqual(outputRandom[i, j], 0.0f);
+            }
+        }
+    }
+    #endregion
+}
+

--- a/Evo_Roguelike/Assets/Tests/EditTests/GeneratorTests.cs.meta
+++ b/Evo_Roguelike/Assets/Tests/EditTests/GeneratorTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3ae102c0f72a00742b4da8e34ee262d8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summarize what is being added
Adding the classes required for the generation of the noise texture for the terrain. This is the first layer of the PCG generation pipeline. More details can be found [here](https://docs.google.com/document/d/1nqPryzzFD0PD4skOurE2CPtDM8No-n84bYrsUz6Ap2E/edit#heading=h.rlpih07zufcq).

## Please describe how to test
Code and unit tests have been included as part of the deliverables of this PR but reviewers can go to the PCGTestScene and hit play. The quad in the scene should be populated with a texture that shows the noise.

## Relevant Screenshots
![image](https://github.com/dERP-Games/Evo_Roguelike/assets/9394777/2e1c8f3f-6ac4-49e0-8167-baa47c66c9e6)
![image](https://github.com/dERP-Games/Evo_Roguelike/assets/9394777/d9c9fbb9-239e-4fdf-8059-0b325bfc3f14)


## What task does this PR address?
This task is related to #36 

## What Sprint is this due in?
Current sprint